### PR TITLE
Add background modal for SuggestionPage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
 
 <body>
   <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="background-modal"></div>
   <div id="modal_root"></div>
   <div id="root"></div>
 </body>

--- a/src/pages/SuggestionsPage/components/FeedbackBar/FeedbackBar.jsx
+++ b/src/pages/SuggestionsPage/components/FeedbackBar/FeedbackBar.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { SelectOption } from './SelectOption';
 import { AddFeedBackBtn } from '../../../../components/AddFeedBackBtn';
+import { Modal } from '../Modal/Modal';
 import arrowUp from '../../../../assets/icons/arrow-up-white.svg';
 import arrowDown from '../../../../assets/icons/arrow-down-white.svg';
 import styles from './_feedbackBar.module.scss';
@@ -62,41 +63,49 @@ export const FeedbackBar = () => {
   }, [isDropDownOpen]);
 
   return (
-    <div className={styles.container}>
-      <div className={styles.contentBox}>
-        <div
-          className={styles.selectContainer}
-          onClick={handleDropdown}
-          ref={containerRef}
-        >
-          <div className={'sortTabContainer'}>
-            <span className={styles.sortText}>sort by : </span>
-            <span
-              className={styles.sortTitle}
-              onKeyPress={handleKeyPress}
-              tabIndex="0"
-            >
-              {activeOptionText}
-              <img className={styles.arrow} src={arrow} alt="" />
-            </span>
-          </div>
-          {isDropDownOpen && (
-            <div className={styles.selectOptions}>
-              {SELECT_OPTIONS.map((option, index) => {
-                return (
-                  <SelectOption
-                    sortingData={SORTING_DATA}
-                    option={option}
-                    index={index}
-                    key={option}
-                  />
-                );
-              })}
+    <>
+      {isDropDownOpen && (
+        <Modal
+          isDropDownOpen={isDropDownOpen}
+          setIsDropDownOpen={setIsDropDownOpen}
+        />
+      )}
+      <div className={styles.container}>
+        <div className={styles.contentBox}>
+          <div
+            className={styles.selectContainer}
+            onClick={handleDropdown}
+            ref={containerRef}
+          >
+            <div className={'sortTabContainer'}>
+              <span className={styles.sortText}>sort by : </span>
+              <span
+                className={styles.sortTitle}
+                onKeyPress={handleKeyPress}
+                tabIndex="0"
+              >
+                {activeOptionText}
+                <img className={styles.arrow} src={arrow} alt="" />
+              </span>
             </div>
-          )}
+            {isDropDownOpen && (
+              <div className={styles.selectOptions}>
+                {SELECT_OPTIONS.map((option, index) => {
+                  return (
+                    <SelectOption
+                      sortingData={SORTING_DATA}
+                      option={option}
+                      index={index}
+                      key={option}
+                    />
+                  );
+                })}
+              </div>
+            )}
+          </div>
+          <AddFeedBackBtn styles={styles} />
         </div>
-        <AddFeedBackBtn styles={styles} />
       </div>
-    </div>
+    </>
   );
 };

--- a/src/pages/SuggestionsPage/components/FeedbackBar/_feedbackBar.module.scss
+++ b/src/pages/SuggestionsPage/components/FeedbackBar/_feedbackBar.module.scss
@@ -57,6 +57,7 @@
   box-shadow: 3px 3px 13px #bdbdbd;
   font-family: $roboto;
   cursor: pointer;
+  z-index: 3;
 }
 
 .option {

--- a/src/pages/SuggestionsPage/components/Modal/Modal.jsx
+++ b/src/pages/SuggestionsPage/components/Modal/Modal.jsx
@@ -1,0 +1,21 @@
+import { createPortal } from 'react-dom';
+
+export const Modal = ({ isDropDownOpen, setIsDropDownOpen }) => {
+  const handleModalClick = () => setIsDropDownOpen(!isDropDownOpen);
+
+  return createPortal(
+    <div
+      onClick={handleModalClick}
+      style={{
+        position: 'fixed',
+        top: '0',
+        left: '0',
+        width: '100%',
+        height: '100vh',
+        backgroundColor: 'transparent',
+        zIndex: '2',
+      }}
+    ></div>,
+    document.getElementById('background-modal')
+  );
+};


### PR DESCRIPTION
When the sort dropdown is open on the Suggestion page, if the user
wanted to close the dropdown by clicking on the body it would fire the
click event listeners of the suggestion boxes and send the user to
another page. With the modal as a transparent background, the modal acts
as a way of closing the dropdown when it's clicked on.