### PR TITLE
Add keyboard user detection function

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { SuggestionsPage } from './pages/SuggestionsPage';
 import { AddFeedbackPage } from './pages/AddFeedbackPage';
 import { FeedbackDetailPage } from './pages/FeedbackDetailPage';
 import { EditFeedback } from './pages/FeedbackDetailPage/components/EditFeedback';
+import { keyboardDetectInit } from './utils/keyboardUserDetect';
 import { NotFoundPage } from './pages/NotFoundPage';
 import './index.scss';
 
@@ -21,5 +22,7 @@ function App() {
     </div>
   );
 }
+
+keyboardDetectInit();
 
 export default App;

--- a/src/index.scss
+++ b/src/index.scss
@@ -23,3 +23,7 @@ body {
 .App {
   height: 100%;
 }
+
+body:not(.keyboardUser) *:focus {
+  outline: none;
+}

--- a/src/pages/AddFeedbackPage/components/FeatureType/_featureType.module.scss
+++ b/src/pages/AddFeedbackPage/components/FeatureType/_featureType.module.scss
@@ -67,7 +67,7 @@
   position: absolute;
   box-shadow: 3px 3px 13px #bdbdbd;
   width: 15rem;
-  top: 0.9rem;
+  top: 3rem;
   border-radius: 20px;
 }
 

--- a/src/sass/base/_reset.scss
+++ b/src/sass/base/_reset.scss
@@ -70,7 +70,6 @@ video {
   margin: 0;
   padding: 0;
   border: 0;
-  // outline: 0;
   vertical-align: baseline;
   background: transparent;
 }

--- a/src/utils/keyboardUserDetect.js
+++ b/src/utils/keyboardUserDetect.js
@@ -1,0 +1,29 @@
+// detect keyboard users
+
+export const keyboardDetectInit = () => {
+  const keyboardUserCssClass = 'keyboardUser';
+
+  function setIsKeyboardUser(isKeyboard) {
+    const { body } = document;
+    if (isKeyboard) {
+      body.classList.contains(keyboardUserCssClass) ||
+        body.classList.add(keyboardUserCssClass);
+    } else {
+      body.classList.remove(keyboardUserCssClass);
+    }
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Tab') {
+      setIsKeyboardUser(true);
+    }
+  });
+  document.addEventListener('click', (e) => {
+    // Pressing ENTER on buttons triggers a click event with coordinates to 0
+    setIsKeyboardUser(!e.screenX && !e.screenY);
+  });
+
+  document.addEventListener('mousedown', (e) => {
+    setIsKeyboardUser(false);
+  });
+};


### PR DESCRIPTION
ISSUE: elements with a tabindex assigned to them have an outline when
focused by touch or click

SOLVED: created and initiated a function to add or remove styles based
on whether or not the focus is from the keyboard or mouse click. Now the
outline styles only appear on tabindexed elements when focused on by the
keyboard.