### PR TITLE
fixed error outline issue

### DIFF
--- a/src/pages/AddFeedbackPage/components/DetailInput/DetailInput.jsx
+++ b/src/pages/AddFeedbackPage/components/DetailInput/DetailInput.jsx
@@ -2,12 +2,7 @@ import { useState, useEffect } from 'react';
 import { InputDescription } from '../../../../components/InputDescription';
 import styles from './_detailInput.module.scss';
 
-export const DetailInput = ({
-  onInputChange,
-  formData,
-  detailError,
-  detailMaxCharacterError,
-}) => {
+export const DetailInput = ({ onInputChange, formData, detailError }) => {
   const [detailCharactersLeft, setDetailCharactersLeft] = useState(75);
 
   useEffect(() => {
@@ -35,10 +30,7 @@ export const DetailInput = ({
       </span>
       <textarea
         id="detailTextArea"
-        className={`${styles.textArea} ${
-          (detailError && styles.errorOutline) ||
-          (detailMaxCharacterError && styles.errorOutline)
-        }`}
+        className={`${styles.textArea} ${detailError && styles.errorOutline}`}
         onChange={onChange}
         value={formData.detail}
         name="detail"

--- a/src/pages/AddFeedbackPage/components/FeedbackForm/FeedbackForm.jsx
+++ b/src/pages/AddFeedbackPage/components/FeedbackForm/FeedbackForm.jsx
@@ -8,8 +8,6 @@ import styles from './_feedbackForm.module.scss';
 export const FeedbackForm = () => {
   const [titleError, setTitleError] = useState(false);
   const [detailError, setDetailError] = useState(false);
-  const [titleMaxCharacterError, setTitleMaxCharacterError] = useState(false);
-  const [detailMaxCharacterError, setDetailMaxCharacterError] = useState(false);
   const [formData, setFormData] = useState({
     title: '',
     category: '',
@@ -32,21 +30,17 @@ export const FeedbackForm = () => {
       return setTitleError(!titleError);
     }
 
-    if (formData.title.length >= 35) {
-      return setTitleMaxCharacterError(true);
-    }
-
     if (!formData.detail) {
       return setDetailError(!detailError);
     }
 
-    if (formData.detail.length >= 75) {
-      return setDetailMaxCharacterError(true);
+    if (formData.detail.length >= 75 || formData.title.length >= 35) {
+      console.log('error');
+      return;
     }
+
     setTitleError(false);
-    setTitleMaxCharacterError(false);
     setDetailError(false);
-    setDetailMaxCharacterError(false);
     console.log('submitted');
 
     return null;
@@ -73,14 +67,12 @@ export const FeedbackForm = () => {
                 onInputChange={onInputChange}
                 formData={formData}
                 titleError={titleError}
-                titleMaxCharacterError={titleMaxCharacterError}
               />
               <FeatureType setFormData={setFormData} />
               <DetailInput
                 onInputChange={onInputChange}
                 formData={formData}
                 detailError={detailError}
-                detailMaxCharacterError={detailMaxCharacterError}
               />
             </form>
             <div className={styles.buttonBox}>

--- a/src/pages/AddFeedbackPage/components/TitleInput/TitleInput.jsx
+++ b/src/pages/AddFeedbackPage/components/TitleInput/TitleInput.jsx
@@ -1,12 +1,7 @@
 import { InputDescription } from '../../../../components/InputDescription';
 import styles from './_titleInput.module.scss';
 
-export const TitleInput = ({
-  onInputChange,
-  formData,
-  titleError,
-  titleMaxCharacterError,
-}) => {
+export const TitleInput = ({ onInputChange, formData, titleError }) => {
   return (
     <div className={styles.inputBox}>
       <InputDescription
@@ -25,10 +20,7 @@ export const TitleInput = ({
       </span>
       <input
         id="feedbackTitle"
-        className={`${styles.inputText} ${
-          (titleError && styles.errorOutline) ||
-          (titleMaxCharacterError && styles.errorOutline)
-        }`}
+        className={`${styles.inputText} ${titleError && styles.errorOutline}`}
         type="text"
         onChange={onInputChange}
         name="title"

--- a/src/pages/FeedbackDetailPage/components/EditFeedback/components/DetailInput/DetailInput.jsx
+++ b/src/pages/FeedbackDetailPage/components/EditFeedback/components/DetailInput/DetailInput.jsx
@@ -2,12 +2,7 @@ import { useState, useEffect } from 'react';
 import { InputDescription } from '../../../../../../components/InputDescription';
 import styles from './_detailInput.module.scss';
 
-export const DetailInput = ({
-  onInputChange,
-  formData,
-  detailError,
-  detailMaxCharacterError,
-}) => {
+export const DetailInput = ({ onInputChange, formData, detailError }) => {
   const [detailCharactersLeft, setDetailCharactersLeft] = useState(75);
 
   useEffect(() => {
@@ -35,10 +30,7 @@ export const DetailInput = ({
       </span>
       <textarea
         id="detailTextArea"
-        className={`${styles.textArea} ${
-          (detailError && styles.errorOutline) ||
-          (detailMaxCharacterError && styles.errorOutline)
-        }`}
+        className={`${styles.textArea} ${detailError && styles.errorOutline}`}
         onChange={onChange}
         value={formData.detail}
         name="detail"

--- a/src/pages/FeedbackDetailPage/components/EditFeedback/components/EditForm/EditForm.jsx
+++ b/src/pages/FeedbackDetailPage/components/EditFeedback/components/EditForm/EditForm.jsx
@@ -9,7 +9,6 @@ import styles from './_editForm.module.scss';
 export const EditForm = () => {
   const [titleError, setTitleError] = useState(false);
   const [detailError, setDetailError] = useState(false);
-  const [titleMaxCharacterError, setTitleMaxCharacterError] = useState(false);
   const [detailMaxCharacterError, setDetailMaxCharacterError] = useState(false);
   const [formData, setFormData] = useState({
     title: '',
@@ -34,19 +33,15 @@ export const EditForm = () => {
       return setTitleError(!titleError);
     }
 
-    if (formData.title.length >= 35) {
-      return setTitleMaxCharacterError(true);
-    }
-
     if (!formData.detail) {
       return setDetailError(!detailError);
     }
 
-    if (formData.detail.length >= 75) {
-      return setDetailMaxCharacterError(true);
+    if (formData.detail.length >= 75 || formData.title.length >= 35) {
+      console.log('error');
+      return;
     }
     setTitleError(false);
-    setTitleMaxCharacterError(false);
     setDetailError(false);
     setDetailMaxCharacterError(false);
     console.log('submitted');
@@ -75,7 +70,6 @@ export const EditForm = () => {
                 onInputChange={onInputChange}
                 formData={formData}
                 titleError={titleError}
-                titleMaxCharacterError={titleMaxCharacterError}
               />
               <FeatureType setFormData={setFormData} />
               <UpdateStatus setFormData={setFormData} />

--- a/src/pages/FeedbackDetailPage/components/EditFeedback/components/TitleInput/TitleInput.jsx
+++ b/src/pages/FeedbackDetailPage/components/EditFeedback/components/TitleInput/TitleInput.jsx
@@ -1,12 +1,7 @@
 import { InputDescription } from '../../../../../../components/InputDescription';
 import styles from './_titleInput.module.scss';
 
-export const TitleInput = ({
-  onInputChange,
-  formData,
-  titleError,
-  titleMaxCharacterError,
-}) => {
+export const TitleInput = ({ onInputChange, formData, titleError }) => {
   return (
     <div className={styles.inputBox}>
       <InputDescription
@@ -25,10 +20,7 @@ export const TitleInput = ({
       </span>
       <input
         id="feedbackTitle"
-        className={`${styles.inputText} ${
-          (titleError && styles.errorOutline) ||
-          (titleMaxCharacterError && styles.errorOutline)
-        }`}
+        className={`${styles.inputText} ${titleError && styles.errorOutline}`}
         type="text"
         onChange={onInputChange}
         name="title"


### PR DESCRIPTION
ISSUE: Error outline on input fields would not be removed when user
fixes the character amount

SOLVED: Removed the outline error and just left it to the character
limit text warning. Placed a conditional in the editform & addfeeedback
parent components to return if the character length is too long.