### PR TITLE
Remove refactored code for Suggestion tablet

### DIFF
--- a/src/pages/SuggestionsPage/components/Suggestion/Suggestion.jsx
+++ b/src/pages/SuggestionsPage/components/Suggestion/Suggestion.jsx
@@ -14,28 +14,6 @@ export const Suggestion = ({ request, sortType }) => {
       <div className={styles.container}>
         <Link to={`/feedback-detail/${request.requestID}`}>
           <div className={styles.innerContainer}>
-            <span
-              className={`${styles.likesTotal} ${
-                request.upvoted && styles.active
-              } `}
-              onClick={(e) => {
-                e.preventDefault();
-                dispatch({
-                  type: 'upvote-sort',
-                  requestID: request.requestID,
-                  sortType: sortType,
-                });
-              }}
-              tabIndex="0"
-            >
-              <img
-                className={styles.likeArrow}
-                src={request.upvoted ? arrowUpWhite : arrowUp}
-                alt="arrow up"
-              />
-              {request.upvotes}
-            </span>
-
             <div className={styles.textBox}>
               <span className={styles.title}>{request.title}</span>
               <p className={styles.description} lang="en">
@@ -44,17 +22,39 @@ export const Suggestion = ({ request, sortType }) => {
               <span className={styles.category}>{request.category}</span>
             </div>
 
-            <div className={styles.commentBox}>
-              <img
-                className={`${styles.commentBubble} ${
-                  request.comments.length > 9 && styles.customPositionRight
+            <div className={styles.likesBox}>
+              <span
+                className={`${styles.likesTotal} ${
+                  request.upvoted && styles.active
                 }`}
-                src={comment}
-                alt="comment bubble"
-              />
-              <span className={styles.commentsTotal}>
-                {request.comments ? request.comments.length : 0}
+                onClick={(e) => {
+                  e.preventDefault();
+                  dispatch({
+                    type: 'upvote',
+                    requestID: request.requestID,
+                  });
+                }}
+                tabIndex="0"
+              >
+                <img
+                  className={styles.likeArrow}
+                  src={request.upvoted ? arrowUpWhite : arrowUp}
+                  alt="arrow up"
+                />
+                {request.upvotes}
               </span>
+              <div className={styles.commentBox}>
+                <img
+                  className={`${styles.commentBubble} ${
+                    request.comments.length > 9 && styles.customPositionRight
+                  }`}
+                  src={comment}
+                  alt="comment bubble"
+                />
+                <span className={styles.commentsTotal}>
+                  {request.comments ? request.comments.length : 0}
+                </span>
+              </div>
             </div>
           </div>
         </Link>

--- a/src/pages/SuggestionsPage/components/Suggestion/_suggestion.module.scss
+++ b/src/pages/SuggestionsPage/components/Suggestion/_suggestion.module.scss
@@ -8,32 +8,12 @@
 }
 
 .innerContainer {
-  padding: 1.8rem 0 6.6rem 0;
-  width: 90%;
-  width: 84%;
-  margin: auto;
-  display: flex;
-  background-color: $white;
-  align-items: center;
-  position: relative;
-  align-items: center;
-  justify-content: center;
-  border-radius: 10px;
-
-  @include tabletMd {
-    width: 96%;
-    padding-bottom: 1.8rem;
-  }
+  padding: 1.5rem 0;
 }
 
 .textBox {
-  width: 100%;
+  width: 84%;
   margin: auto;
-
-  @include tabletMd {
-    width: 68%;
-    margin: 0 1.9rem 0 2.2rem;
-  }
 }
 
 .title {
@@ -81,11 +61,6 @@
 .likeArrow {
   position: relative;
   right: 7px;
-
-  @include tabletMd {
-    right: 0;
-    bottom: 0.6rem;
-  }
 }
 
 .likesTotal {
@@ -94,17 +69,6 @@
   color: $darkNavy;
   padding: 0.7rem 1.3rem;
   border-radius: 0.5rem;
-  position: absolute;
-  left: 0;
-  bottom: 2.2rem;
-
-  @include tabletMd {
-    position: static;
-    flex-direction: column;
-    justify-content: center;
-    padding: 1.2rem 0;
-    min-width: 49px;
-  }
 }
 
 .commentBox {
@@ -113,13 +77,6 @@
   align-items: center;
   justify-content: space-between;
   padding-top: 0.3rem;
-  position: absolute;
-  bottom: 2.6rem;
-  right: 0;
-
-  @include tabletMd {
-    position: static;
-  }
 }
 
 .commentBubble {


### PR DESCRIPTION
Reapplied default styles before refactor for tablets. This look of the
suggestions look much better with the styles already
implemented. Less cluttered than the figma design for tablet styles.